### PR TITLE
v4.0 Slice 2 — Contact section

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { LanguageProvider } from './i18n/LanguageContext'
 import { ThemeProvider } from './i18n/ThemeContext'
 import Nav from './components/Nav'
 import Hero from './components/Hero'
+import Contact from './components/Contact'
 import Footer from './components/Footer'
 
 export default function App() {
@@ -14,6 +15,7 @@ export default function App() {
           <Nav />
           <main>
             <Hero />
+            <Contact />
           </main>
           <Footer />
         </div>

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -1,115 +1,61 @@
-import React, { useRef, useState } from 'react'
+import React from 'react'
 import { useLanguage } from '../i18n/LanguageContext'
-import useInView from '../hooks/useInView'
-import SectionLabel from './_shared/SectionLabel'
+import data from '../data/contact.json'
 
-const EMAIL = 'andresmontoyat@gmail.com'
+function pick(field, lang) {
+  if (typeof field === 'string') return field
+  return field?.[lang] ?? field?.en ?? ''
+}
+
+function Card({ card, lang }) {
+  const k = pick(card.kLabel, lang)
+  const v = card.value
+  const classes =
+    'block bg-surface border border-border rounded-[14px] p-6 text-center '
+    + 'transition-all duration-300 hover:border-accent hover:-translate-y-1 '
+    + 'hover:shadow-[0_20px_30px_-20px_rgba(0,229,168,0.3)]'
+  const inner = (
+    <>
+      <div className="text-3xl mb-3 text-accent" aria-hidden="true">{card.icon}</div>
+      <div className="text-xs uppercase tracking-widest text-muted mb-1.5">{k}</div>
+      <div className="text-sm font-semibold text-text break-all">{v}</div>
+    </>
+  )
+  if (!card.href) {
+    return (
+      <div className={classes} aria-label={`${k}: ${v}`}>
+        {inner}
+      </div>
+    )
+  }
+  return (
+    <a
+      href={card.href}
+      title={k}
+      {...(card.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+      className={classes}
+    >
+      {inner}
+    </a>
+  )
+}
 
 export default function Contact() {
-  const { t } = useLanguage()
-  const sectionRef = useRef(null)
-  const inView = useInView(sectionRef, { threshold: 0.25 })
-
+  const { lang } = useLanguage()
   return (
     <section id="contact" className="py-20">
-      <div ref={sectionRef} className="max-w-6xl mx-auto px-6">
-        <div className={`animate-on-scroll${inView ? ' is-visible' : ''}`}>
-          <SectionLabel>{t.contact.label}</SectionLabel>
-          <h2 className="text-3xl sm:text-4xl font-extrabold tracking-tight text-text-primary mb-3">{t.contact.h2}</h2>
-          <p className="text-text-secondary max-w-2xl mb-10">{t.contact.intro}</p>
+      <div className="max-w-6xl mx-auto px-6">
+        <div className="font-mono text-xs uppercase tracking-[3px] text-accent flex items-center gap-3 mb-4">
+          <span className="block w-10 h-0.5 bg-accent" /> {pick(data.label, lang)}
         </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-10">
-          <EmailHeroCard
-            t={t}
-            inView={inView}
-            className="sm:col-span-3"
-            style={{ transitionDelay: '100ms' }}
-          />
-          <SecondaryCard
-            href="tel:+573244422196"
-            symbol="#"
-            label={t.contact.phone}
-            value="+57 324 442 2196"
-            inView={inView}
-            style={{ transitionDelay: '200ms' }}
-          />
-          <SecondaryCard
-            href="https://www.linkedin.com/in/carlos-andres-montoya-tobon-8b508033"
-            symbol="in"
-            label="LinkedIn"
-            value="carlos-andres-montoya-tobon"
-            external
-            inView={inView}
-            style={{ transitionDelay: '300ms' }}
-          />
-          <SecondaryCard
-            href="https://github.com/andresmontoyat"
-            symbol="gh"
-            label="GitHub"
-            value="andresmontoyat"
-            external
-            inView={inView}
-            style={{ transitionDelay: '400ms' }}
-          />
+        <h2 className="text-3xl sm:text-4xl md:text-[42px] font-extrabold tracking-tight text-text mb-4 leading-tight">
+          {pick(data.h2, lang)}
+        </h2>
+        <p className="text-muted max-w-[640px] mb-12 text-base">{pick(data.intro, lang)}</p>
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-4">
+          {data.cards.map((c) => <Card key={c.id} card={c} lang={lang} />)}
         </div>
       </div>
     </section>
-  )
-}
-
-function EmailHeroCard({ t, inView, className = '', style }) {
-  const [copied, setCopied] = useState(false)
-
-  function handleCopy(e) {
-    e.preventDefault()
-    if (!navigator.clipboard || !navigator.clipboard.writeText) return
-    navigator.clipboard.writeText(EMAIL).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    }).catch(() => {})
-  }
-
-  return (
-    <a
-      href={`mailto:${EMAIL}`}
-      className={`block bg-ink-500 border border-ink-400 rounded-xl p-6 hover:border-brand hover:-translate-y-1 transition-all duration-200 animate-on-scroll${inView ? ' is-visible' : ''} ${className}`}
-      style={style}
-    >
-      <div className="font-mono text-xs text-text-muted uppercase tracking-wider mb-2">
-        {t.contact.email}
-      </div>
-      <div className="flex items-center justify-between gap-4 flex-wrap">
-        <div className="text-3xl sm:text-4xl font-extrabold text-text-primary break-all">
-          {EMAIL}
-        </div>
-        <button
-          type="button"
-          onClick={handleCopy}
-          aria-label="Copy email to clipboard"
-          className="flex-shrink-0 font-mono text-xs text-brand border border-brand/30 hover:border-brand rounded-full px-3 py-2 transition-colors duration-150 min-h-[44px] min-w-[80px] text-center"
-        >
-          <span aria-live="polite">
-            {copied ? 'Copied!' : 'Copy email'}
-          </span>
-        </button>
-      </div>
-    </a>
-  )
-}
-
-function SecondaryCard({ href, symbol, label, value, external, inView, style }) {
-  return (
-    <a
-      href={href}
-      target={external ? '_blank' : undefined}
-      rel={external ? 'noopener noreferrer' : undefined}
-      className={`block bg-ink-500 border border-ink-400 rounded-xl p-6 text-center hover:border-brand hover:-translate-y-1 transition-all duration-200 animate-on-scroll${inView ? ' is-visible' : ''}`}
-      style={style}
-    >
-      <div className="font-mono text-3xl text-brand mb-3 font-extrabold">{symbol}</div>
-      <div className="text-xs uppercase tracking-wider text-text-secondary mb-2">{label}</div>
-      <div className="text-base font-extrabold text-text-primary break-all">{value}</div>
-    </a>
   )
 }

--- a/src/components/Contact.test.js
+++ b/src/components/Contact.test.js
@@ -1,0 +1,84 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LanguageProvider } from '../i18n/LanguageContext'
+import Contact from './Contact'
+import data from '../data/contact.json'
+
+function setLangBeforeRender(lang) {
+  try {
+    window.localStorage.setItem('cam-lang', lang)
+  } catch (e) {
+    // ignore
+  }
+}
+
+function renderWithLang(lang = 'en') {
+  setLangBeforeRender(lang)
+  return render(
+    <LanguageProvider>
+      <Contact />
+    </LanguageProvider>,
+  )
+}
+
+describe('Contact (v4.0 Slice 2)', () => {
+  it('renders the section with id="contact"', () => {
+    const { container } = renderWithLang('en')
+    expect(container.querySelector('section#contact')).toBeInTheDocument()
+  })
+
+  it('renders exactly 5 contact cards', () => {
+    renderWithLang('en')
+    expect(screen.getByText('andresmontoyat@gmail.com')).toBeInTheDocument()
+    expect(screen.getByText('+57 324 442 2196')).toBeInTheDocument()
+    expect(screen.getByText('carlos-andres-montoya-tobon')).toBeInTheDocument()
+    expect(screen.getByText('andresmontoyat')).toBeInTheDocument()
+    expect(screen.getByText('Medellín, Colombia')).toBeInTheDocument()
+  })
+
+  it('Email card href is mailto:', () => {
+    renderWithLang('en')
+    const el = screen.getByText('andresmontoyat@gmail.com').closest('a')
+    expect(el).not.toBeNull()
+    expect(el.getAttribute('href')).toBe('mailto:andresmontoyat@gmail.com')
+  })
+
+  it('external cards (LinkedIn, GitHub) open in new tab with rel=noopener noreferrer', () => {
+    renderWithLang('en')
+    const linkedin = screen.getByText('carlos-andres-montoya-tobon').closest('a')
+    const github = screen.getByText('andresmontoyat').closest('a')
+    for (const a of [linkedin, github]) {
+      expect(a).not.toBeNull()
+      expect(a.getAttribute('target')).toBe('_blank')
+      expect(a.getAttribute('rel')).toBe('noopener noreferrer')
+    }
+  })
+
+  it('Location is NOT a link (no anchor wrapper)', () => {
+    renderWithLang('en')
+    const el = screen.getByText('Medellín, Colombia')
+    expect(el.closest('a')).toBeNull()
+  })
+
+  it('translates label/h2/intro and kLabels when lang=es', () => {
+    renderWithLang('es')
+    expect(screen.getByText('Contacto')).toBeInTheDocument()
+    expect(screen.getByText('Construyamos algo juntos')).toBeInTheDocument()
+    expect(screen.getByText('Correo')).toBeInTheDocument()
+    expect(screen.getByText('Teléfono')).toBeInTheDocument()
+    expect(screen.getByText('Ubicación')).toBeInTheDocument()
+  })
+
+  it('contact.json schema sanity — 5 cards, each with required keys', () => {
+    expect(Array.isArray(data.cards)).toBe(true)
+    expect(data.cards).toHaveLength(5)
+    for (const c of data.cards) {
+      expect(typeof c.id).toBe('string')
+      expect(typeof c.icon).toBe('string')
+      expect(typeof c.value).toBe('string')
+      expect(typeof c.kLabel.en).toBe('string')
+      expect(typeof c.kLabel.es).toBe('string')
+    }
+  })
+})

--- a/src/data/contact.json
+++ b/src/data/contact.json
@@ -1,0 +1,44 @@
+{
+  "label": { "en": "Contact", "es": "Contacto" },
+  "h2": { "en": "Let's build something", "es": "Construyamos algo juntos" },
+  "intro": { "en": "Open to senior backend, architecture and technical leadership roles. Feel free to reach out.", "es": "Abierto a roles senior de backend, arquitectura y liderazgo técnico. Escríbeme sin pena." },
+  "cards": [
+    {
+      "id": "email",
+      "icon": "✉",
+      "kLabel": { "en": "Email", "es": "Correo" },
+      "value": "andresmontoyat@gmail.com",
+      "href": "mailto:andresmontoyat@gmail.com"
+    },
+    {
+      "id": "phone",
+      "icon": "☎",
+      "kLabel": { "en": "Phone", "es": "Teléfono" },
+      "value": "+57 324 442 2196",
+      "href": "tel:+573244422196"
+    },
+    {
+      "id": "linkedin",
+      "icon": "in",
+      "kLabel": { "en": "LinkedIn", "es": "LinkedIn" },
+      "value": "carlos-andres-montoya-tobon",
+      "href": "https://www.linkedin.com/in/carlos-andres-montoya-tobon-8b508033",
+      "external": true
+    },
+    {
+      "id": "github",
+      "icon": "gh",
+      "kLabel": { "en": "GitHub", "es": "GitHub" },
+      "value": "andresmontoyat",
+      "href": "https://github.com/andresmontoyat",
+      "external": true
+    },
+    {
+      "id": "location",
+      "icon": "◆",
+      "kLabel": { "en": "Location", "es": "Ubicación" },
+      "value": "Medellín, Colombia",
+      "href": null
+    }
+  ]
+}

--- a/src/i18n/translations.js
+++ b/src/i18n/translations.js
@@ -163,13 +163,6 @@ const translations = {
         devops: 'DevOps automation',
       },
     },
-    contact: {
-      label: 'Contact',
-      h2: "Let's build something",
-      intro: 'Open to senior backend, architecture and technical leadership roles. Feel free to reach out.',
-      phone: 'Phone',
-      email: 'Email',
-    },
     footer: {
       rights: 'All rights reserved',
       tagline: 'I write code. Let\'s build something amazing together.',
@@ -338,13 +331,6 @@ const translations = {
         legacy: 'Legacy refactor',
         devops: 'DevOps automation',
       },
-    },
-    contact: {
-      label: 'Contacto',
-      h2: 'Construyamos algo juntos',
-      intro: 'Abierto a roles senior de backend, arquitectura y liderazgo técnico. Escríbeme sin pena.',
-      phone: 'Teléfono',
-      email: 'Correo',
     },
     footer: {
       rights: 'Todos los derechos reservados',


### PR DESCRIPTION
## Summary

Second slice of v4.0 portfolio MVP redesign. Lands the Contact section as a 5-card responsive grid (Email / Phone / LinkedIn / GitHub / Location) backed by a new `src/data/contact.json`. Establishes the JSON-per-section pattern future slices reuse.

- ➕ `src/data/contact.json` — single source for label/h2/intro + 5 cards, bilingual `{ en, es }` envelope.
- ♻️ `src/components/Contact.js` — replaced parked 115-line component with ~70-line JSON-driven version. Visual contract calques `website-new/index.html` `.contact-grid` + `.contact-card` (surface bg, border, hover translateY −4 px + accent border).
- ❌ `t.contact` subtree stripped from `src/i18n/translations.js` (both EN and ES blocks). No surviving consumers.
- 🔗 `<Contact />` wired into `App.js` between `<Hero />` and `<Footer />`.

Visual reference: `website-new/index.html`.
Spec: `docs/superpowers/specs/2026-06-12-contact-section-design.md`
Plan: `docs/superpowers/plans/2026-06-12-contact-section.md`

**Base branch:** `v4.0-slice-1-purge` (stacks on top of PR #26 — merge that first).

## Test plan

- [x] `npm test -- --run` — **20/20 GREEN** (Slice 1's 13 + new Contact 7).
- [x] `npm run build` — clean, single `index-*.js` chunk.
- [x] `node scripts/check-bundle-gate.mjs` — exit 0 (`53.73 kB gz`, WARN 60, HARD 68 — 14 kB headroom).
- [x] `npm run lighthouse:mobile` — Perf 0.99 / A11y 1.00 / BP 1.00 / SEO 1.00.
- [ ] Visual smoke on Vercel preview — 5 cards render, hover translateY works, EN↔ES toggle translates labels, LinkedIn + GitHub open in new tab, Location does NOT navigate.

## Next slice

Slice 3 — **About**: `.about-grid` `1.2fr / .8fr` layout with bilingual narrative + Quick Facts side card. Reuses the JSON-per-section pattern landed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)