### PR TITLE
perf(v4.1): static hero LCP fix — 0.84 → 0.98

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,18 @@
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>Carlos Andrés Montoya Tobón · Solutions Architect &amp; Senior Backend Engineer</title>
+    <!-- Critical CSS — static hero layer paints before React hydrates (kills LCP render delay) -->
+    <style>
+      :root {
+        --hero-photo-filter: grayscale(0.2) brightness(0.35);
+        --hero-overlay: linear-gradient(180deg, rgba(13, 13, 26, 0.4) 0%, rgba(13, 13, 26, 0.95) 75%);
+      }
+      html, body { margin: 0; padding: 0; background: #0D0D1A; }
+      #hero-static { position: absolute; top: 0; left: 0; right: 0; height: 100vh; z-index: 0; overflow: hidden; pointer-events: none; }
+      #hero-static img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; object-position: center 30%; filter: var(--hero-photo-filter); }
+      #hero-static .hero-static-ovl { position: absolute; inset: 0; background: var(--hero-overlay); }
+      #root { position: relative; z-index: 1; }
+    </style>
     <!-- Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-4TZJGR3MXR"></script>
     <script>
@@ -49,6 +61,16 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="hero-static" aria-hidden="true">
+      <img
+        src="/me-800.webp"
+        srcset="/me-400.webp 400w, /me-800.webp 800w, /me-1600.webp 1600w"
+        sizes="100vw"
+        alt=""
+        fetchpriority="high"
+      />
+      <div class="hero-static-ovl"></div>
+    </div>
     <div id="root"></div>
     <script type="module" src="/src/index.js"></script>
   </body>

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -55,24 +55,8 @@ export default function Hero() {
   return (
     <section
       id="hero"
-      className="relative min-h-screen flex items-center bg-hero-gradient pt-16 pb-16 overflow-hidden"
+      className="relative min-h-screen flex items-center pt-16 pb-16 overflow-hidden"
     >
-      <img
-        src="/me-800.webp"
-        srcSet="/me-400.webp 400w, /me-800.webp 800w, /me-1600.webp 1600w"
-        sizes="100vw"
-        alt=""
-        fetchpriority="high"
-        decoding="async"
-        className="absolute inset-0 z-0 w-full h-full object-cover"
-        style={{ objectPosition: 'center 30%', filter: 'var(--hero-photo-filter)' }}
-      />
-      <div
-        aria-hidden="true"
-        className="absolute inset-0 z-0 pointer-events-none"
-        style={{ background: 'var(--hero-overlay)' }}
-      />
-
       <div className="relative z-10 max-w-6xl mx-auto px-6 py-20 w-full">
         <span
           className="inline-flex items-center gap-2 px-4 py-1.5 border border-ink-400 rounded-full font-mono text-xs text-text-secondary bg-ink-500 mb-6 motion-safe:opacity-0 motion-safe:animate-fade-in"


### PR DESCRIPTION
## Summary

- Move hero `<img>` + dark overlay out of React tree into `index.html` as static layer behind `#root` — removes React hydration from the LCP critical path
- Hero `<section>` drops `bg-hero-gradient` + inner img/overlay; transparent over the static photo + overlay
- Inline minimal critical CSS in `<head>` for hero photo filter + overlay vars (dark theme defaults; theme toggle parked)

## Lighthouse mobile (local, simulated throttling)

| Metric | Before | After |
|---|---|---|
| Performance | 0.84 | **0.98** |
| LCP | ~4.0s | **2.1s** |
| FCP | — | 1.8s |
| TBT | — | 0 ms |
| CLS | — | 0.014 |
| Accessibility | 1.0 | 1.0 |
| Best Practices | 1.0 | 1.0 |
| SEO | 1.0 | 1.0 |

Root cause (memory 2026-06-14): React SPA hydration was blocking LCP with 2.76s render delay (68% of total). Static HTML hero lets the browser paint the LCP element on first paint after CSS — no JS parse/execute/mount required.

## Test plan

- [x] `npm run test:run` — 57/57 GREEN
- [x] `npm run build:gate` — 60.78 kB gz (under HARD 68, WARN 60)
- [x] Local Lighthouse mobile — Perf 0.98, all gates PASS
- [ ] Vercel preview deploy — verify visual parity (photo + overlay + content positioning)
- [ ] Production Lighthouse after merge — confirm 0.95+ gate on `*.vercel.app`
- [ ] Light theme verify (if/when theme toggle revived)

🤖 Generated with [Claude Code](https://claude.com/claude-code)