### PR TITLE
perf(v4.1): make static hero img LCP-eligible

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,15 +61,15 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="hero-static" aria-hidden="true">
+    <div id="hero-static">
       <img
         src="/me-800.webp"
         srcset="/me-400.webp 400w, /me-800.webp 800w, /me-1600.webp 1600w"
         sizes="100vw"
-        alt=""
+        alt="Carlos Andrés Montoya Tobón"
         fetchpriority="high"
       />
-      <div class="hero-static-ovl"></div>
+      <div class="hero-static-ovl" aria-hidden="true"></div>
     </div>
     <div id="root"></div>
     <script type="module" src="/src/index.js"></script>


### PR DESCRIPTION
## Summary

Follow-up to PR #34. Production Lighthouse after #34 showed Perf 0.83 with LCP element = Nav anchor text (not the hero photo) at 4.1s. Root cause: `aria-hidden="true"` on `#hero-static` disqualified the img from LCP candidacy per the LCP element selection spec — so the LCP fell back to the next React-rendered candidate (Nav text), which is gated by hydration.

Fix:
- Remove `aria-hidden` from `#hero-static`
- Add descriptive `alt="Carlos Andrés Montoya Tobón"` on the img (also a small a11y win — the hero photo is the subject, not pure decoration)
- Keep `aria-hidden="true"` on the dark overlay div (correctly decorative)

## Local Lighthouse mobile

- Performance **0.98** | LCP **2.1s** | FCP 1.8s | TBT 0ms | CLS 0.014
- A11y 1.0 / BP 1.0 / SEO 1.0 — all PASS

## Test plan

- [x] `npm run test:run` — 57/57 GREEN
- [x] `npm run build:gate` — 60.78 kB gz
- [x] Local Lighthouse — Perf 0.98, all gates PASS
- [ ] Vercel build SUCCESS
- [ ] Post-merge prod Lighthouse on `andresmontoyatco.vercel.app` — Perf ≥ 0.95

🤖 Generated with [Claude Code](https://claude.com/claude-code)