### PR TITLE
docs(state): sync STATE.md + ROADMAP.md to v4.2 reality

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -8,15 +8,30 @@
 - ⏸ **v3.7 — Production Deploy** *(PAUSED, opened 2026-05-20 — deferred 2026-05-29)* — Vercel auto-deploy done (site live on `*.vercel.app`); Phase 11 Plan 11-05 Lighthouse mobile gate verdict, custom domain (Phase 12), and PR previews (Phase 13) **carried as deferred**. Resumes in a future milestone. Phases 11–13 reserved — NOT renumbered.
 - ✅ **v3.8 — Game Mode** *(SHIPPED 2026-06-06)* — Interactive skill-constellation landing (node=skill, edges=co-occurrence), floating bilingual experience cards, multi-skill/year/category filters, persisted game/dev toggle. Adaptive render (WebGL desktop / SVG-DOM mobile) holds the Lighthouse mobile HARD gate (cleared Perf ≥95 / A11y 100 / BP 100 / SEO 100). Vitest + RTL test infra introduced (253 tests GREEN). 8/8 REQs delivered (GAME-01..07 + TEST-01). Phases 14–17. See [`milestones/v3.8-ROADMAP.md`](milestones/v3.8-ROADMAP.md).
 - ✅ **v3.9 — Game Mode Polish** *(SHIPPED 2026-06-08)* — Micro-milestone. Two UX fixes shipped same-day: above-the-fold layout (SkillFilters → fixed bottom-0 z-30; H1 compact; renderer slot flex-1) and never-static constellation (SVG ambient twinkle, prefers-reduced-motion gated). 2/2 REQs delivered (POLISH-01, POLISH-02). 261/261 tests GREEN. Phases 18–19.
-- 🟢 **v3.10 — 3D Constellation** *(ACTIVE, opened 2026-06-08)* — Genuine 3D upgrade on existing desktop WebGL renderer: PerspectiveCamera(fov=55) + OrbitControls drag-to-rotate + category-z layout. Activates SEED-3D-CONSTELLATION. 1 REQ (DEPTH-01) / 1 phase (Phase 20) / 4 plans / 3–5 days. Mobile SVG path UNCHANGED — Lighthouse mobile HARD gate intact. Zero new deps (already-installed `three@0.169.0` ships both new imports). See [`v3.10-REQUIREMENTS.md`](REQUIREMENTS.md) and [`research/SUMMARY.md`](research/SUMMARY.md).
+- ✅ **v3.10 — 3D Constellation** *(SHIPPED 2026-06-10, tag `v3.10`/`v3.10.1`)* — Genuine 3D upgrade on desktop WebGL renderer: PerspectiveCamera(fov=55) + OrbitControls drag-to-rotate + category-z layout. 1 REQ (DEPTH-01) / Phase 20 / 4 plans. Mobile SVG path UNCHANGED. 293/293 tests GREEN. **Entire game-mode/WebGL lineage (v3.8–v3.10) superseded by v4.0 purge.** See [`milestones/v3.10-ROADMAP.md`](milestones/v3.10-ROADMAP.md).
+- ✅ **v4.0 — Portfolio Redesign (JSON-Driven Refactor)** *(SHIPPED 2026-06-13, tag `v4.0`)* — Purged game-mode/Mario-world/WebGL/ViewMode lineage; dark palette tokens (#0B1020/#00E5A8/#00C2FF); 7 sections refactored to `src/data/<section>.json` bilingual contracts + 7-spec test files (PRs #26–#32). Killed `dangerouslySetInnerHTML`. 57/57 tests GREEN.
+- ✅ **v4.1 — Deploy Polish (OG + LCP perf)** *(SHIPPED 2026-06-16, tag `v4.1`)* — Static hero `<img>` moved to index.html (kill React-hydration LCP delay) + LCP eligibility fix + OG refresh (PRs #33–#35). Prod Lighthouse mobile: Perf 0.84→**0.99**, LCP 4.0s→**2.1s**; A11y/BP/SEO 1.0.
+- 🟢 **v4.2 — Content Polish** *(IN PROGRESS, no tag)* — Recruiter-facing content quality. Experience copy rewrite (tNic template, 12 entries) + timeline UI polish (PRs #36–#37); projects 3-card redesign (emoji glyphs + gradient overlay + flexbox) + contact reorder (PR #38); npm audit fix (PR #39). 16 obsolete dependabot PRs closed (dead CRA toolchain). 57/57 tests GREEN. Backlog: VIS-05, DIAGRAMS-01, custom domain.
 
 ---
 
 ## Phases
 
-### v3.10 3D Constellation (Phase 20) — 🟢 ACTIVE
+### v4.2 Content Polish — 🟢 ACTIVE (slice-based, on main)
 
-- [ ] **Phase 20: 3D Constellation** (DEPTH-01) — genuine 3D + drag-to-rotate on desktop WebGL; SVG mobile path untouched
+> Content-quality milestone, no fixed phase count. Slices ship directly to main as PRs; no v4.2 tag until passes converge.
+
+- [x] **Experience rewrite** — tNic template, 12 entries, JSON-driven (PR #36 `9684201`)
+- [x] **Experience timeline UI polish** — interactive states (PR #37 `8ec5ed2`)
+- [x] **Projects 3-card redesign + contact reorder** — emoji glyphs + gradient overlay + flexbox; GitHub before LinkedIn (PR #38 `57be81d`)
+- [x] **Dependency hygiene** — npm audit fix non-breaking (PR #39); 16 obsolete dependabot PRs closed (dead CRA toolchain)
+- [ ] **VIS-05** — claude-kanban + caveman cards into Claude section (3 of 5 featured-app cards present)
+- [ ] **DIAGRAMS-01** — cross-repo architecture diagrams
+- [ ] **Custom domain** `andresmontoyat.co` + DNS (carried from v4.1)
+
+### v3.10 3D Constellation (Phase 20) — ✅ SHIPPED (superseded by v4.0 purge)
+
+- [x] **Phase 20: 3D Constellation** (DEPTH-01) — genuine 3D + drag-to-rotate on desktop WebGL; SVG mobile path untouched. Entire WebGL lineage stripped from main by v4.0.
 
 ### v3.7 Production Deploy (Phases 11–13) — ⏸ DEFERRED
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,19 +1,43 @@
 ---
 gsd_state_version: 1.0
-milestone: v4.1
-milestone_name: Deploy polish — OG + LCP perf
-status: shipped
-stopped_at: v4.1 tag placed (7e2c34c); prod Lighthouse mobile Perf 0.99 / A11y 1.0 / BP 1.0 / SEO 1.0 — all gates PASS
-last_updated: 2026-06-16T15:15:00.000Z
-last_activity: 2026-06-16 -- v4.1 tagged; prod Perf 0.84 → 0.99, LCP 4.0s → 2.1s
+milestone: v4.2
+milestone_name: Content polish — experience rewrite + projects redesign
+status: in-progress
+stopped_at: v4.2 content work on main (no tag yet) — experience rewrite (#36) + timeline polish (#37) + projects 3-card redesign + contact reorder (#38) + audit fix (#39). 57/57 tests GREEN.
+last_updated: 2026-06-22T19:14:00-05:00
+last_activity: 2026-06-22 -- merged #38 + #39; closed 16 obsolete dependabot PRs (dead CRA toolchain); STATE+ROADMAP synced to v4.2
 progress:
-  total_slices: 7
-  completed_slices: 7
-  remaining_slices: 0
-  percent: 100
+  shipped_to_main: 4
+  remaining: open  # VIS-05 + content passes; no fixed slice count yet
+  percent: null
 ---
 
 # Project State
+
+## v4.2 Content Polish (IN PROGRESS — on main, no tag)
+
+**Focus:** Recruiter-facing content quality — experience copy rewrite + projects section redesign. No infra/perf scope.
+
+**Shipped to main (PR order):**
+
+| PR | Commit | Description |
+|----|--------|-------------|
+| #36 | 9684201 | Experience rewrite — apply tNic template (Fase 1); 12 entries, JSON-driven |
+| #37 | 8ec5ed2 | Experience timeline UI polish (interactive states) |
+| #38 | 57be81d | Projects 3-card redesign (🎫 Mr. Yoker / 🏥 Mutual SER / 📞 Hexadialer) — emoji glyphs + gradient overlay + centered flexbox (fixed card width, replaces grid); contact reorder (GitHub before LinkedIn) |
+| #39 | 7e3c27e | npm audit fix — non-breaking security bumps (25→23 vulns) |
+
+**Dependency hygiene (2026-06-22):** Closed 16 obsolete dependabot PRs (#5–#24) — all targeted the removed CRA/craco toolchain (craco, react-scripts, axios, lodash + transitives no longer in package.json post-Vite migration). Inmergeable + no-op.
+
+**Carried concerns:**
+- **23 vulns remain** (20 moderate, 1 high, 2 critical) — ALL devDependencies (vite/vitest/@vitest/coverage-v8/esbuild/lighthouse build+test toolchain). NOT shipped to static prod bundle → no end-user exposure. Fix needs `--force` major bumps of vite+vitest → deliberate toolchain upgrade, deferred.
+- **No v4.2 tag** — content work unbounded (no fixed slice count). Tag when content passes converge.
+- **projects-input.md** (`.planning/`) holds the raw project intake (Mr. Yoker filled; Atenea + others blank) — source for future projects expansion.
+
+**v4.2 backlog (not started):**
+- **VIS-05** — claude-kanban + caveman cards into Claude section (3 of 5 featured-app cards present).
+- **DIAGRAMS-01** — cross-repo architecture diagrams.
+- Custom domain `andresmontoyat.co` (carried from v4.1).
 
 ## Project Reference
 
@@ -112,9 +136,10 @@ Root cause closed: React SPA hydration was blocking the LCP critical path. Hero 
 
 ## Session Continuity
 
-Last session: 2026-06-16T15:15:00.000Z (v4.1 tagged; prod gate PASS)
-Stopped at: v4.1 milestone complete. Both tags pushed. Prod live.
+Last session: 2026-06-22T19:14:00-05:00 (resumed; merged PRs + synced docs)
+Stopped at: #38 + #39 merged to main; 16 obsolete dependabot PRs closed; STATE.md + ROADMAP.md synced to v4.2 reality. main clean, 57/57 GREEN.
 Resume file: none — clean checkpoint
+Open PR: #2 junie-init only (foreign JetBrains scaffold — close if unused)
 
 ## v4.2 Roadmap Candidates (next milestone)
 


### PR DESCRIPTION
Planning docs were stale: ROADMAP marked v3.10 ACTIVE with no v4.0/v4.1/v4.2 entries; STATE header frozen at "v4.1 shipped". Both now reflect main.

- v3.10 → SHIPPED (superseded by v4.0 purge)
- v4.0 / v4.1 added as shipped (tags + metrics)
- v4.2 Content Polish → IN PROGRESS (#36–#39)
- Recorded: 16 obsolete dependabot PRs closed; 23 devDep vulns deferred
- Backlog: VIS-05, DIAGRAMS-01, custom domain

Docs-only. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)